### PR TITLE
fix: find package name for locally created packages which do not provide a package name as as attr of the defining rule

### DIFF
--- a/strict_deps/index.bzl
+++ b/strict_deps/index.bzl
@@ -5,7 +5,11 @@ NpmPackage = provider()
 
 def _npm_package_aspect_impl(target, ctx):
     if (ctx.rule.kind == 'npm_link_package_store'):
-        return [NpmPackage(name=ctx.rule.attr.package)]
+        package_name = ctx.rule.attr.package
+        # TODO: Determine how to include the package field information in locally built npm package targets
+        if package_name == '':
+            package_name = target[JsInfo].npm_package_store_infos.to_list()[0].package
+        return [NpmPackage(name=package_name)]
     return []
 
 


### PR DESCRIPTION
This works to look at the `npm_package_store_infos` when the package name is not defined as an attribute on the rule.  Since local packages are always included in the `npm_package_store_infos` when linked, they will always appear and be available.

The more correct method is still to find how we can include the package name "correctly" so that it is included by `npm_link_package_store`