### PR TITLE
Set up `npmrc` in `npm_translate_lock`

### DIFF
--- a/setup/step_1.bzl
+++ b/setup/step_1.bzl
@@ -3,6 +3,7 @@ load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
 def step_1():
     npm_translate_lock(
         name = "rules_angular_npm",
+        npmrc = "//:.npmrc",
         data = [
             "@rules_angular//:package.json",
         ],


### PR DESCRIPTION
This was missing and causes warnings.