### PR TITLE
refactor: switch macros to @angular/cli

### DIFF
--- a/src/architect/ng_application.bzl
+++ b/src/architect/ng_application.bzl
@@ -1,7 +1,7 @@
 "Macro definition to build and serve an application"
 
 load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_run_devserver")
-load(":utils.bzl", "TEST_PATTERNS", "TOOLS", "ng_bin")
+load(":utils.bzl", "TEST_PATTERNS", "ng_bin")
 
 # Idiomatic configuration files created by `ng generate`
 APPLICATION_CONFIG = [
@@ -10,11 +10,7 @@ APPLICATION_CONFIG = [
 
 # # Typical dependencies of angular apps
 NPM_DEPS = lambda node_modules: ["/".join([node_modules, s]) for s in [
-    "@angular/common",
-    "@angular/core",
-    "@angular/router",
-    "@angular/platform-browser",
-    "@angular/platform-browser-dynamic",
+    "@angular",  # Take all of them, since the list varies across angular versions
     "rxjs",
     "tslib",
     "zone.js",
@@ -34,19 +30,18 @@ def ng_application(name, node_modules, ng_config, project_name = None, srcs = []
       **kwargs: extra args passed to main Angular CLI rules
     """
     srcs = srcs or native.glob(["src/**/*"], exclude = TEST_PATTERNS)
-    deps = deps + NPM_DEPS(node_modules)
+    deps = deps + NPM_DEPS(node_modules) + APPLICATION_CONFIG
+    deps.append(ng_config)
     project_name = project_name if project_name else name
     tool = ng_bin(name, node_modules)
 
     js_run_binary(
         name = name,
         chdir = native.package_name(),
-        args = ["%s:build" % project_name],
+        args = ["build", project_name],
         out_dirs = ["dist"],
         tool = tool,
-        srcs = srcs + deps + APPLICATION_CONFIG + TOOLS(node_modules) + [
-            ng_config,
-        ],
+        srcs = srcs + deps,
         **kwargs
     )
 
@@ -55,7 +50,5 @@ def ng_application(name, node_modules, ng_config, project_name = None, srcs = []
         tool = tool,
         chdir = native.package_name(),
         args = ["%s:serve" % project_name],
-        data = srcs + deps + APPLICATION_CONFIG + TOOLS(node_modules) + [
-            ng_config,
-        ],
+        data = srcs + deps,
     )

--- a/src/architect/ng_config.bzl
+++ b/src/architect/ng_config.bzl
@@ -15,11 +15,15 @@ JQ_DIST_REPLACE_TSCONFIG = """
 # Similarly update paths in angular.json
 JQ_DIST_REPLACE_ANGULAR = """
 (
-  .projects[] | 
-  select(.architect?.build?.options?.outputPath)
-) |= (
-  .architect.build.options.outputPath |= gsub("^dist/(?<p>.+)$"; "projects/"+.p+"/dist")
-)
+  .projects | to_entries | map(
+    if .value.projectType == "application" then
+      .value.architect.build.options.outputPath = "projects/" + .key + "/dist"
+    else
+      .
+    end
+  ) | from_entries
+) as $updated |
+. * {projects: $updated}
 """
 
 # buildifier: disable=function-docstring

--- a/src/architect/utils.bzl
+++ b/src/architect/utils.bzl
@@ -8,27 +8,25 @@ TEST_PATTERNS = [
     "dist/",
 ]
 
-TOOLS = lambda node_modules: ["/".join([node_modules, s]) for s in [
-    "@angular-devkit/build-angular",
-]]
-
 # Syntax sugar:
 # Reproduce the behavior of the logic a user would get from 
-# load("@npm//angular:@angular-devkit/architect-cli/package_json.bzl", architect_cli = "bin")
+# load("@npm//angular:@angular/cli/package_json.bzl", angular_cli = "bin")
+def ng_entry_point(name, node_modules):
+    entry_point_target = "_{}.ng_entry_point".format(name)
+    directory_path(
+        name = entry_point_target,
+        directory = "{}/@angular/cli/dir".format(node_modules),
+        path = "bin/ng.js",
+    )
+    return entry_point_target
+
 # buildifier: disable=function-docstring
 def ng_bin(name, node_modules):
-    entry_point = "_{}_architect_entry_point".format(name)
-    directory_path(
-        name = entry_point,
-        directory = "{}/@angular-devkit/architect-cli/dir".format(node_modules),
-        path = "bin/architect.js",
-    )
-
-    bin = "_{}_architect_binary".format(name)
+    bin_target = "_{}.ng_binary".format(name)
     js_binary(
-        name = bin,
-        data = ["{}/@angular-devkit/architect-cli".format(node_modules)],
-        entry_point = entry_point,
+        name = bin_target,
+        data = ["{}/@angular/cli".format(node_modules)],
+        entry_point = ng_entry_point(name, node_modules),
     )
 
-    return bin
+    return bin_target


### PR DESCRIPTION
Greatly simplifies code, and works with the npm deps users already take. Otherwise we have to instruct them to add @angular-devkit packages to their devDeps.

Also includes fixes to make it work with Angular v20 which has slightly different dependencies and different `angular.json`