### PR TITLE
Support applications not following `projects/<..>` structure and different configurations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,8 @@
 common --@aspect_rules_ts//ts:skipLibCheck=always
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
+build --symlink_prefix=dist
+
 # For remote testing
 # -----
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bazel-*
 node_modules/
 .vscode/
+dist/

--- a/src/architect/ng_application.bzl
+++ b/src/architect/ng_application.bzl
@@ -16,7 +16,15 @@ NPM_DEPS = lambda node_modules: ["/".join([node_modules, s]) for s in [
     "zone.js",
 ]]
 
-def ng_application(name, node_modules, ng_config, project_name = None, srcs = [], deps = [], **kwargs):
+def ng_application(
+        name,
+        node_modules,
+        ng_config,
+        project_name = None,
+        args = [],
+        srcs = [],
+        deps = [],
+        **kwargs):
     """
     Bazel macro for compiling an NG application project. Creates {name}, {name}.serve targets.
 
@@ -24,6 +32,7 @@ def ng_application(name, node_modules, ng_config, project_name = None, srcs = []
       name: the rule name
       node_modules: users installed and linked angular dependencies
       project_name: the Angular CLI project name, to the rule name
+      args: Extra arguments to pass to `ng build`.
       srcs: application source files: typescript, HTML, and styles
       ng_config: angular workspace root configs
       deps: dependencies of the application, typically ng_library rules
@@ -38,7 +47,7 @@ def ng_application(name, node_modules, ng_config, project_name = None, srcs = []
     js_run_binary(
         name = name,
         chdir = native.package_name(),
-        args = ["build", project_name],
+        args = ["build", project_name] + args,
         out_dirs = ["dist"],
         tool = tool,
         srcs = srcs + deps,

--- a/src/architect/ng_config.bzl
+++ b/src/architect/ng_config.bzl
@@ -1,25 +1,28 @@
 "Macro definition to copy & modify root config files"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 
 # JQ expressions to update Angular project output paths from dist/* to projects/*/dist
 # We do this to avoid mutating the files in the source tree, so that the native tooling without Bazel continues to work.
+# Note: This assumes that 1P linking projects follow the `projects/<project>/` folder structure.
 JQ_DIST_REPLACE_TSCONFIG = """
-    .compilerOptions.paths |= map_values(
+    .compilerOptions.paths |= if . then map_values(
       map(
         gsub("^dist/(?<p>.+)$"; "projects/"+.p+"/dist")
       )
-    )
+    ) else {} end
 """
+
 # Similarly update paths in angular.json
+# This time we can properly know the project root and have the `dist` folder
+# local to the BUILD file of the target/project.
 JQ_DIST_REPLACE_ANGULAR = """
 (
   .projects | to_entries | map(
     .value.architect.test.options.preserveSymlinks = true
     |
     if .value.projectType == "application" then
-      .value.architect.build.options.outputPath = "projects/" + .key + "/dist"
+      .value.architect.build.options.outputPath = .value.root + "/dist"
     else
       .
     end

--- a/src/architect/ng_test.bzl
+++ b/src/architect/ng_test.bzl
@@ -9,8 +9,9 @@ TEST_CONFIG = [
 ]
 
 NPM_DEPS = lambda node_modules: ["/".join([node_modules, s]) for s in [
-    "@angular", # Take all of them, since the list varies across angular versions
+    "@angular",  # Take all of them, since the list varies across angular versions
     "@types/jasmine",
+    "@types/node",
     "jasmine-core",
     "karma-chrome-launcher",
     "karma-coverage",
@@ -21,7 +22,7 @@ NPM_DEPS = lambda node_modules: ["/".join([node_modules, s]) for s in [
     "zone.js",
 ]]
 
-def ng_test(name, node_modules, ng_config, project_name = None, srcs = [], deps = [], **kwargs):
+def ng_test(name, node_modules, ng_config, args = [], project_name = None, srcs = [], deps = [], **kwargs):
     """
     Bazel macro for compiling an NG library project.
 
@@ -29,6 +30,7 @@ def ng_test(name, node_modules, ng_config, project_name = None, srcs = [], deps 
       name: the rule name
       node_modules: users installed and linked angular dependencies
       srcs: list of labels of source files to include
+      args: Additional command line flags to be passed to `ng test`.
       project_name: the Angular CLI project name, defaults to current directory name
       deps: additional dependencies for tests
       ng_config: root configurations (angular.json, tsconfig.json)
@@ -42,12 +44,10 @@ def ng_test(name, node_modules, ng_config, project_name = None, srcs = [], deps 
     js_test(
         name = name,
         chdir = native.package_name(),
-        args = ["test", project_name, "--no-watch"],
+        args = ["test", project_name, "--no-watch"] + args,
         entry_point = ng_entry_point(name, node_modules),
         data = srcs + deps + TEST_CONFIG + [
             ng_config,
-            ":ng-package",
         ],
-        log_level = "debug",
         **kwargs
     )


### PR DESCRIPTION
Necessary to support `material.angular.io` using these rules.