### PR TITLE
Fixes to support compiler-cli from HEAD

### DIFF
--- a/src/worker/angular/BUILD.bazel
+++ b/src/worker/angular/BUILD.bazel
@@ -20,4 +20,13 @@ js_binary(
     name = "bin",
     data = [":angular_lib"],
     entry_point = ":main_angular.mjs",
+    env = {
+        # NOTE: We disable node FS patches here because symlinks created
+        # by `ctx.actions.symlink` with `target_file` end up resolving outside
+        # of runtime `.runfiles` directories into the sandbox execroot. The FS
+        # patches would block this jump from one root to the other root, but that's
+        # exactly what we need here so that transitive dependencies of e.g. `@angular/compiler-cli`
+        # are resolved based on the configured compiler package.
+        "JS_BINARY__PATCH_NODE_FS": "0",
+    },
 )

--- a/src/worker/file_system.mts
+++ b/src/worker/file_system.mts
@@ -118,7 +118,15 @@ export class WorkerSandboxFileSystem extends BazelSafeFilesystem {
   }
 
   private diskReadlink(filePath: AbsoluteFsPath): AbsoluteFsPath {
-    return this.fromDiskPath(fs.readlinkSync(this.toDiskPath(filePath)));
+    const linkFsPath = this.toDiskPath(filePath);
+    let targetPath = fs.readlinkSync(linkFsPath);
+
+    // Convert relative links to absolute disk paths.
+    if (!path.isAbsolute(targetPath)) {
+      targetPath = path.join(path.dirname(linkFsPath), targetPath);
+    }
+
+    return this.fromDiskPath(targetPath);
   }
 
   private toDiskPath(filePath: AbsoluteFsPath): string {


### PR DESCRIPTION
When trying out using the compiler-cli from HEAD, we couldn't do it before this commit because there was no `JsInfo`. This commit fixes this.

In addition, the symlinks created, as noted, only worked for `.runfiles` runtime execution— so this resulted in some build failures when compiling the worker `ts_project`.

We fix this by using `target_file` symlinks, that are automatically adjusted by Bazel based on where the symlink is needed. i.e. in runfiles dir, or in `bazel-bin`. This solves this nicely.

Unfortunately though, the final problem is that at runtime, due to the new `target_file` option, the symlinks are no longer relative pointing to the pnpm root inside `.runfiles`, but instead point to the execroot. That is because they are now "absolute". Issues now arise when NodeJS tries to find transitive dependencies of e.g. `@angular/compiler-cli`. Such issues arise because `rules_js` generally doesn't support escaping the `.runfiles` to another "safe" root. In this case that is actually desirable, so we turn that patching off to support jumping between the roots (and enable transitive dependency resolution).