### PR TITLE
Fix symlinks for compiler from HEAD breaking in remote execution

### DIFF
--- a/src/private/symlink_package.bzl
+++ b/src/private/symlink_package.bzl
@@ -1,34 +1,69 @@
+load("@aspect_bazel_lib//lib:paths.bzl", "relative_file")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 
 DOC = """
 Rule that symlinks a `//:node_modules/<pkg>` into another `node_modules` folder.
 
-This is useful for cases where node modules cross Bazel repository boundaries, e.g.
-when allowing for a configurable TS version, as otherwise those modules will not be
-resolvable at runtime in hermetic environments (like RBE).
-
-The test environments will not have the execroot `node_modules`, or user workspace
-`node_modules` reachable by traversal up from e.g. `@rules_angular//src/worker/loop.mts`.
-
-(Note: In build actions lookups work as we build in `bin/external/rules_angular`; but not in runfiles!)
+This is useful for enabling a compiler-cli or typescript version from HEAD,
+or configured in the consuming repository.
 """
+
+def manifest_path(ctx, file):
+    # If a short path starts with `../`, then the file is from an external
+    # workspace and we can just strip off the leading segment.
+    if file.short_path.startswith("../"):
+        return file.short_path[3:]
+
+    return "%s/%s" % (ctx.workspace_name, file.short_path)
 
 def _symlink_impl(ctx):
     src = ctx.attr.src
 
     store_info = src[JsInfo].npm_package_store_infos.to_list()[0]
     src_dir = store_info.package_store_directory
-    destination = ctx.actions.declare_directory(ctx.attr.name)
+    src_workspace = src.label.workspace_name if src.label.workspace_name != "" else ctx.workspace_name
+
+    destination = ctx.actions.declare_symlink(ctx.attr.name)
+    destination_build = ctx.actions.declare_symlink(
+        ctx.attr.name.replace("node_modules/", "node_modules_for_build/"),
+    )
+
+    # TODO(devversion): Revisit this with Bazel 7/8 and their new output layout!
+    # This currently generates two symlinked node module structures. One for build actions
+    # running in `bazel-out/../bin` and one for inside `.runfiles` (runtime execution).
+    # This is unfortunately necessary because we have two different folder structures in how
+    # we can reference the sources that potentially reside in a whole different Bazel repository.
+    # See the first layout for build actions:
+    #     bin/
+    #       node_modules/... <-- This folder the symlinks are based on!
+    #       external/rules_angular/src/worker/...
+    # to -->
+    #     .runfiles
+    #       angular_framework/node_modules <--- Different location of pnpm store! :/
+    #       rules_angular/src/worker/...
+    # -----
+    # We can solve this by generating two symlinks. One symlink node modules structure
+    # that is picked up by build actions (via path mappings in the `tsconfig.json`) and one
+    # real `node_modules/` folder that is picked up by NodeJS at runtime.
+
+    ctx.actions.symlink(
+        output = destination_build,
+        # Note: arguments order is swapped compared to NodeJS `path.relative`.
+        target_path = relative_file(src_dir.path, destination.path),
+    )
+
+    src_manifest_path = manifest_path(ctx, src_dir)
+    destination_manifest_path = manifest_path(ctx, destination)
 
     ctx.actions.symlink(
         output = destination,
-        # TODO(devversion): Revisit this with Bazel 7/8 and their new output layout!
-        # This currently generates compatible relative paths for `runfiles`, but in build
-        # tree this is unresolvable (but not a problem; but conceptually weird).
-        target_file = src_dir,
+        # Note 1: arguments order is swapped compared to NodeJS `path.relative`.
+        # Note 2: This path is for the `.runfiles` layout where destination workspace is a
+        #   sibling with its actual workspace name. Hence we use manifest paths for computation.
+        target_path = relative_file(src_manifest_path, destination_manifest_path),
     )
 
-    runfiles = ctx.runfiles(files = [destination])
+    runfiles = ctx.runfiles(files = [destination, destination_build])
 
     return [
         DefaultInfo(
@@ -43,7 +78,7 @@ def _symlink_impl(ctx):
             transitive_types = src[JsInfo].transitive_types,
             npm_package_store_infos = src[JsInfo].npm_package_store_infos,
             npm_sources = depset(
-                [destination],
+                [destination, destination_build],
                 transitive = [src[JsInfo].npm_sources],
             ),
         ),

--- a/src/worker/angular/BUILD.bazel
+++ b/src/worker/angular/BUILD.bazel
@@ -20,13 +20,4 @@ js_binary(
     name = "bin",
     data = [":angular_lib"],
     entry_point = ":main_angular.mjs",
-    env = {
-        # NOTE: We disable node FS patches here because symlinks created
-        # by `ctx.actions.symlink` with `target_file` end up resolving outside
-        # of runtime `.runfiles` directories into the sandbox execroot. The FS
-        # patches would block this jump from one root to the other root, but that's
-        # exactly what we need here so that transitive dependencies of e.g. `@angular/compiler-cli`
-        # are resolved based on the configured compiler package.
-        "JS_BINARY__PATCH_NODE_FS": "0",
-    },
 )

--- a/src/worker/tsconfig.json
+++ b/src/worker/tsconfig.json
@@ -8,6 +8,12 @@
     "strictPropertyInitialization": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "types": ["node"]
-  }
+    "types": ["node"],
+    "paths": {
+      // See `symlink_package.bzl`. This is necessary to support building
+      // with `typescript` and `compiler-cli` from the consumer Bazel repository.
+      "*": ["./node_modules_for_build/*"]
+    }
+  },
+  "exclude": ["node_modules/**"]
 }


### PR DESCRIPTION
Remote executors don't support this variant of `ctx.symlink`, so we need to switch to unresolved symlinks and make sure they are picked up at build time of the worker library, and at runtime.

This commit fixes both. See inline code description.