### PR TITLE
fix: avoid hashing chunk files

### DIFF
--- a/src/ng_package/rollup/rollup.config.js
+++ b/src/ng_package/rollup/rollup.config.js
@@ -217,7 +217,7 @@ const config = {
     sourcemap: !dtsMode,
     banner: bannerContent,
     entryFileNames: `[name].${outputExtension}`,
-    chunkFileNames: `[name]-[hash].${outputExtension}`,
+    chunkFileNames: `[name].${outputExtension}`,
   },
 };
 


### PR DESCRIPTION
Rollup will not emitting conflicting filenames in the case two of them are named the same, instead it will rename one of them by adding a number at the end.

Closes https://github.com/angular/angular/issues/62228