### PR TITLE
fix the file discovery within directories in text_replace

### DIFF
--- a/src/ng_package/angular_package_format.bzl
+++ b/src/ng_package/angular_package_format.bzl
@@ -168,7 +168,7 @@ def _filter_esm_files_to_include(files, owning_package):
     return result
 
 def _angular_package_format_impl(ctx):
-    apf_directory = ctx.actions.declare_directory("%s.apf" % ctx.label.name)
+    apf_directory = ctx.actions.declare_directory(ctx.label.name)
     owning_package = ctx.label.package
 
     # The name of the primary entry-point FESM bundles, computed name from the owning package

--- a/src/ng_package/index.bzl
+++ b/src/ng_package/index.bzl
@@ -26,7 +26,7 @@ def ng_package(
             "%s_apf_substituted" % name,
         ] + nested_packages,
         replace_prefixes = dict({
-            "%s_apf_substituted" % name: "/",
+            "%s_apf_substituted/%s_apf" % (name, name): "/",
             "schematics/npm_package/": "schematics/",
             "schematics/pkg/": "schematics/",
         }, **replace_prefixes),

--- a/src/ng_package/text_replace/index.mts
+++ b/src/ng_package/text_replace/index.mts
@@ -109,7 +109,7 @@ async function main(args: string[]) {
           .map((file: string) => {
             return {
               full: file,
-              relative: file.slice(origin.full.length + 1),
+              relative: file.slice(basePath.length),
             };
           })
       )


### PR DESCRIPTION
We were not properly determining the relative path of files found within directories to apply text replacements