### PR TITLE
use symlinked version of typescript for all typescript dependencies

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,15 @@
+function readPackage(pkg, context) {
+  if (pkg.name === '@angular/compiler-cli') {
+    // Remove typescript from peer dependencies to allow it to be provided
+    // via the symlinked version.
+    delete pkg.peerDependencies['typescript'];
+    delete pkg.peerDependenciesMeta['typescript'];
+  }
+  return pkg;
+}
+
+module.exports = {
+  hooks: {
+    readPackage,
+  },
+};

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@rules_angular_npm//:defs.bzl", "npm_link_all_packages")
+load("//src/private:symlink_package.bzl", "symlink_package")
 
 package(default_visibility = ["//visibility:public"])
 
 npm_link_all_packages()
+
+symlink_package(
+    name = "node_modules/typescript",
+    src = "@rules_angular_configurable_deps//:typescript",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,7 @@ load("//setup:step_3.bzl", "rules_angular_step3")
 
 rules_angular_step3(
     angular_compiler_cli = "//:node_modules/@angular/compiler-cli",
-    typescript = "//:node_modules/typescript",
+    typescript = "//:node_modules/typescript-local",
 )
 
 http_archive(

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rxjs": "^7.8.2",
     "tinyglobby": "0.2.12",
     "tslib": "^2.8.1",
-    "typescript": "5.9.2",
+    "typescript-local": "npm:typescript@5.9.2",
     "zone.js": "^0.15.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+pnpmfileChecksum: sha256-D8BmX3+ClNe2tQNJkiM28QjuUzcX6WVfUFAWQe/wM/I=
+
 importers:
 
   .:
@@ -14,7 +16,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: 20.2.0-next.2
-        version: 20.2.0-next.2(@angular/compiler-cli@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(typescript@5.9.2))(@angular/compiler@20.2.0-next.2)(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@20.2.0-next.2(@angular/common@20.2.0-next.2(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@types/node@22.10.1)(chokidar@4.0.1)(postcss@8.5.6)(terser@5.36.0)(tslib@2.8.1)(typescript@5.9.2)
+        version: 20.2.0-next.2(@angular/compiler-cli@20.2.0-next.2(@angular/compiler@20.2.0-next.2))(@angular/compiler@20.2.0-next.2)(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@20.2.0-next.2(@angular/common@20.2.0-next.2(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@types/node@22.10.1)(chokidar@4.0.1)(postcss@8.5.6)(terser@5.36.0)(tslib@2.8.1)(typescript@5.9.2)
       '@angular/cli':
         specifier: 20.2.0-next.2
         version: 20.2.0-next.2(@types/node@22.10.1)(chokidar@4.0.1)
@@ -26,7 +28,7 @@ importers:
         version: 20.2.0-next.2
       '@angular/compiler-cli':
         specifier: 20.2.0-next.2
-        version: 20.2.0-next.2(@angular/compiler@20.2.0-next.2)(typescript@5.9.2)
+        version: 20.2.0-next.2(@angular/compiler@20.2.0-next.2)
       '@angular/core':
         specifier: 20.2.0-next.2
         version: 20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0)
@@ -81,9 +83,9 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 5.9.2
-        version: 5.9.2
+      typescript-local:
+        specifier: npm:typescript@5.9.2
+        version: typescript@5.9.2
       zone.js:
         specifier: ^0.15.0
         version: 0.15.0
@@ -227,10 +229,6 @@ packages:
     hasBin: true
     peerDependencies:
       '@angular/compiler': 20.2.0-next.2
-      typescript: '>=5.8 <6.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@angular/compiler@20.2.0-next.2':
     resolution: {integrity: sha512-i1FgN0i0znbW8jigPxjVj6qPDQcnf7SwwKWUBBF1PMiXvJlJD4NA3m2p9JtOSFmDdi0rFBhMbV8FX46dEirJBg==}
@@ -2958,12 +2956,12 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@20.2.0-next.2(@angular/compiler-cli@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(typescript@5.9.2))(@angular/compiler@20.2.0-next.2)(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@20.2.0-next.2(@angular/common@20.2.0-next.2(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@types/node@22.10.1)(chokidar@4.0.1)(postcss@8.5.6)(terser@5.36.0)(tslib@2.8.1)(typescript@5.9.2)':
+  '@angular/build@20.2.0-next.2(@angular/compiler-cli@20.2.0-next.2(@angular/compiler@20.2.0-next.2))(@angular/compiler@20.2.0-next.2)(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@20.2.0-next.2(@angular/common@20.2.0-next.2(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(rxjs@7.8.2)(zone.js@0.15.0)))(@types/node@22.10.1)(chokidar@4.0.1)(postcss@8.5.6)(terser@5.36.0)(tslib@2.8.1)(typescript@5.9.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2002.0-next.2(chokidar@4.0.1)
       '@angular/compiler': 20.2.0-next.2
-      '@angular/compiler-cli': 20.2.0-next.2(@angular/compiler@20.2.0-next.2)(typescript@5.9.2)
+      '@angular/compiler-cli': 20.2.0-next.2(@angular/compiler@20.2.0-next.2)
       '@babel/core': 7.28.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
@@ -3039,7 +3037,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@20.2.0-next.2(@angular/compiler@20.2.0-next.2)(typescript@5.9.2)':
+  '@angular/compiler-cli@20.2.0-next.2(@angular/compiler@20.2.0-next.2)':
     dependencies:
       '@angular/compiler': 20.2.0-next.2
       '@babel/core': 7.28.0
@@ -3050,8 +3048,6 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
       yargs: 18.0.0
-    optionalDependencies:
-      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 

--- a/src/worker/BUILD.bazel
+++ b/src/worker/BUILD.bazel
@@ -6,11 +6,6 @@ load("//src/private:symlink_package.bzl", "symlink_package")
 package(default_visibility = ["//visibility:public"])
 
 symlink_package(
-    name = "node_modules/typescript",
-    src = "@rules_angular_configurable_deps//:typescript",
-)
-
-symlink_package(
     name = "node_modules/@angular/compiler-cli",
     src = "@rules_angular_configurable_deps//:angular_compiler_cli",
 )
@@ -45,7 +40,7 @@ ts_project(
     declaration = True,
     tsconfig = "tsconfig",
     deps = [
-        ":node_modules/typescript",
+        "//:node_modules/typescript",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lru-cache",
         "//:node_modules/memfs",
@@ -67,7 +62,7 @@ ts_project(
     tsconfig = "tsconfig",
     deps = [
         ":node_modules/@angular/compiler-cli",  # user-configured compiler
-        ":node_modules/typescript",
+        "//:node_modules/typescript",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lru-cache",
         "//:node_modules/memfs",


### PR DESCRIPTION
We prevent the angular-cli package from bringing in its own version of typescript and instead always rely on the version provided by the workspace setup rules.