### PR TITLE
fix(ng_package): correct d.ts chunk file extension

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-D8BmX3+ClNe2tQNJkiM28QjuUzcX6WVfUFAWQe/wM/I=
+pnpmfileChecksum: sha256-XtUaqxMdcZeX6V2GgPPg1gDpiDUY/qXsjmAn+Gha8jY=
 
 importers:
 

--- a/src/ng_package/rollup/rollup.config.js
+++ b/src/ng_package/rollup/rollup.config.js
@@ -195,8 +195,6 @@ if (dtsMode) {
   );
 }
 
-const outputExtension = dtsMode ? 'd.ts' : 'mjs';
-
 /** @type {import('rollup').RollupOptions} */
 const config = {
   input,
@@ -217,8 +215,8 @@ const config = {
     minifyInternalExports: false,
     sourcemap: !dtsMode,
     banner: bannerContent,
-    entryFileNames: `[name].${outputExtension}`,
-    chunkFileNames: `[name].${outputExtension}`,
+    entryFileNames: '[name].' + (dtsMode ? 'd.ts' : 'mjs'),
+    chunkFileNames: '[name].' + (dtsMode ? 'ts' : 'mjs'),
   },
 };
 


### PR DESCRIPTION
When generating d.ts files with rollup, if a chunk name already contained `.d`, the output file would have a `.d.d.ts` extension.

This change adjusts the output chunk file extension to `.ts` when in dts mode, preventing the double extension issue.

Before
<img width="419" height="308" alt="Screenshot 2025-09-25 at 13 18 51" src="https://github.com/user-attachments/assets/07a47917-00e3-41a4-915e-896d9655f5cd" />
After
<img width="415" height="370" alt="Screenshot 2025-09-25 at 13 20 52" src="https://github.com/user-attachments/assets/b0804a7a-af7a-42ce-80af-fc2f7828eea1" />
